### PR TITLE
Test and fix some minor issues with updateProfileController

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -167,7 +167,7 @@ export const testController = (req, res) => {
 //update prfole
 export const updateProfileController = async (req, res) => {
   try {
-    const { name, email, password, address, phone } = req.body;
+    const { name, password, address, phone } = req.body;
     const user = await userModel.findById(req.user._id);
     //password
     if (password && password.length < 6) {
@@ -186,14 +186,14 @@ export const updateProfileController = async (req, res) => {
     );
     res.status(200).send({
       success: true,
-      message: "Profile Updated SUccessfully",
+      message: "Profile Updated Successfully",
       updatedUser,
     });
   } catch (error) {
     console.log(error);
     res.status(400).send({
       success: false,
-      message: "Error WHile Update profile",
+      message: "Error While Update profile",
       error,
     });
   }


### PR DESCRIPTION
### Summary
Write unit test for `updateProfileController`(in `authController.js`)

### Current Test Cases
1. Return 200 and null, if user not found but got non-empty value
2. Return 400, if user not found and only empty values
3. Return 400, if given password has less than 6 characters
4. Return 200 and updated user, if given some valid new values
5. Return 200 and original user, if given empty values only

### Current Issues
1. `updateProfileController` destructure email from request body even though it does not handle and update user's email based on the new value. The frontend interface does not allow for updating of email either.
2. User handling for profile update is a bit weird. It just assumes that user id is always valid without checking if `findById` and `findByIdAndUpdate` returns a non-null value or not. This results in the following two weird behaviours:
    2.1: If user is not found and body contains only empty values, error will be triggered in backend due to type error(dereferencing null).
    2.2 If user is not found and body contains non-empty values, the controller works and returns 200 status ok, but the updatedUser field in the res data is null.
3. For 2, even though there's probably no real production issue because user probably can always be found, but I am worrying if I miss any edge cases. 

### Solution
1. Removed email from request body in the controller to avoid confusion. The unit tests do not test on updating email either.
2. For issue 2 & 3, will check with TA myself.