### PR TITLE
Test search result page and fix some errors

### DIFF
--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -7,7 +7,7 @@ const Search = () => {
     <Layout title={"Search results"}>
       <div className="container">
         <div className="text-center">
-          <h1>Search Resuts</h1>
+          <h1>Search Results</h1>
           <h6>
             {values?.results.length < 1
               ? "No Products Found"
@@ -15,7 +15,7 @@ const Search = () => {
           </h6>
           <div className="d-flex flex-wrap mt-4">
             {values?.results.map((p) => (
-              <div className="card m-2" style={{ width: "18rem" }}>
+              <div className="card m-2" style={{ width: "18rem" }} key={p._id}>
                 <img
                   src={`/api/v1/product/product-photo/${p._id}`}
                   className="card-img-top"
@@ -24,11 +24,11 @@ const Search = () => {
                 <div className="card-body">
                   <h5 className="card-title">{p.name}</h5>
                   <p className="card-text">
-                    {p.description.substring(0, 30)}...
+                    {p.description?.substring(0, 30)}...
                   </p>
                   <p className="card-text"> $ {p.price}</p>
-                  <button class="btn btn-primary ms-1">More Details</button>
-                  <button class="btn btn-secondary ms-1">ADD TO CART</button>
+                  <button className="btn btn-primary ms-1">More Details</button>
+                  <button className="btn btn-secondary ms-1">ADD TO CART</button>
                 </div>
               </div>
             ))}

--- a/client/src/pages/Search.test.js
+++ b/client/src/pages/Search.test.js
@@ -1,0 +1,205 @@
+import React from 'react';
+import { render } from "@testing-library/react";
+import '@testing-library/jest-dom/extend-expect';
+import Search from './Search';
+
+jest.mock('../context/search', () => ({
+    useSearch: jest.fn(),
+}));
+
+import { useSearch } from "../context/search";
+import {MemoryRouter} from "react-router-dom";
+
+jest.mock('../components/Layout', () => ({title, children}) => {
+   return (
+        <div>
+            <h1 className="text-center">{title}</h1>
+            {children}
+        </div>
+   );
+});
+
+describe('Search Page', () => {
+    const mockProduct1 = {
+        _id: "1",
+        name: "Mock Product 1",
+        description: "Mock Description 1",
+        price: 99.99,
+    };
+
+    const mockProduct2 = {
+        _id: "2",
+        name: "Mock Product 2",
+        description: "Mock Description 2",
+        price: 999.99,
+    };
+
+    const mockProduct3 = {
+        _id: "3",
+        name: "Mock Product 3",
+        description: "Mock Description 3",
+        price: 9999.99,
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render correctly with empty search result', () => {
+        // Arrange
+        useSearch.mockReturnValue([
+            {
+                keyword: "",
+                results: []
+            },
+            jest.fn()
+        ]);
+
+        // Act
+        const { getByText, queryByText } = render(
+            <Search/>
+        );
+
+        // Assert
+        expect(getByText("Search Results", { exact: true })).toBeInTheDocument();
+        expect(getByText("No Products Found", {exact: true})).toBeInTheDocument();
+        expect(queryByText(/More Details/i)).not.toBeInTheDocument();
+        expect(queryByText(/ADD TO CART/i)).not.toBeInTheDocument();
+    });
+
+    it('should render correctly with one search result', () => {
+        // Arrange
+        const mockResults = [mockProduct1];
+        useSearch.mockReturnValue([
+            {
+                keyword: "",
+                results: mockResults
+            },
+            jest.fn()
+        ]);
+
+        // Act
+        const { getByText, getAllByText } = render(
+            <Search/>
+        );
+
+        // Assert
+        expect(getByText('Search Results', { exact: true })).toBeInTheDocument();
+        expect(getByText(`Found ${mockResults.length}`, { exact: true })).toBeInTheDocument();
+        expect(getByText(mockProduct1.name)).toBeInTheDocument();
+        expect(getByText(mockProduct1.description.substring(0, 30) + "...")).toBeInTheDocument();
+        expect(getByText("$ " + mockProduct1.price)).toBeInTheDocument();
+        expect(getAllByText(/^More Details$/i)).toHaveLength(1);
+        expect(getAllByText(/^ADD TO CART$/i)).toHaveLength(1);
+    });
+
+    it('should render correctly with multiple search results', () => {
+        // Arrange
+        const mockResults = [mockProduct1, mockProduct2, mockProduct3];
+        useSearch.mockReturnValue([
+            {
+                keyword: "",
+                results: mockResults
+            },
+            jest.fn()
+        ]);
+
+        // Act
+        const { getByText, getAllByText } = render(
+            <Search/>
+        );
+
+        // Assert
+        expect(getByText("Search Results", { exact: true })).toBeInTheDocument();
+        expect(getByText(`Found ${mockResults.length}`, { exact: true })).toBeInTheDocument();
+        mockResults.forEach(product => {
+            expect(getByText(product.name)).toBeInTheDocument();
+            expect(getByText(product.description.substring(0, 30) + "...")).toBeInTheDocument();
+            expect(getByText("$ " + product.price)).toBeInTheDocument();
+        });
+        expect(getAllByText(/More Details/i)).toHaveLength(3);
+        expect(getAllByText(/ADD TO CART/i)).toHaveLength(3);
+    });
+
+    const fields = ["name", "description", "price"]
+    test.each(fields)(
+        'should render correctly even if results contain empty fields', (field) => {
+            // Arrange
+            const mockResults = [{
+                ...mockProduct1,
+                [field]: ""
+            }];
+            useSearch.mockReturnValue([{
+                keyword: "",
+                results: mockResults
+            },
+                jest.fn()
+            ]);
+
+            // Act
+            const { getByText, getAllByText, queryByText } = render(
+                <Search/>
+            );
+
+            // Assert
+            expect(getByText("Search Results", { exact: true })).toBeInTheDocument();
+            expect(getByText(`Found ${mockResults.length}`, { exact: true })).toBeInTheDocument();
+            fields.forEach(f => {
+                if (f === field) {
+                    expect(queryByText(new RegExp(mockProduct1[f], 'i'))).not.toBeInTheDocument();
+                    return;
+                }
+                expect(getByText(new RegExp(mockProduct1[f], 'i'))).toBeInTheDocument();
+            });
+            expect(getAllByText(/More Details/i)).toHaveLength(1);
+            expect(getAllByText(/ADD TO CART/i)).toHaveLength(1);
+    });
+
+    test.each(fields)(
+        'should still render properly even if results contain null fields', (field) => {
+            // Arrange
+            const mockResults = [{
+                ...mockProduct1,
+                [field]: null
+            }];
+            useSearch.mockReturnValue([{
+                keyword: "",
+                results: mockResults
+            },
+                jest.fn()
+            ]);
+
+            // Act
+            const { getByText, getAllByText, queryByText } = render(
+                <Search/>
+            );
+
+            // Assert
+            expect(getByText("Search Results", { exact: true })).toBeInTheDocument();
+            expect(getByText(`Found ${mockResults.length}`, { exact: true })).toBeInTheDocument();
+            fields.forEach(f => {
+                if (f === field) {
+                    expect(queryByText(new RegExp(mockProduct1[f], 'i'))).not.toBeInTheDocument();
+                    return;
+                }
+                expect(getByText(new RegExp(mockProduct1[f], 'i'))).toBeInTheDocument();
+            });
+            expect(getAllByText(/More Details/i)).toHaveLength(1);
+            expect(getAllByText(/ADD TO CART/i)).toHaveLength(1);
+        });
+
+    it('should throw error if results does not resolve correctly', () => {
+        // Arrange
+        useSearch.mockReturnValue([
+            { keyword: "", results: null },
+        ]);
+
+        // Act
+        const renderAttempt = () => render(
+            <Search/>
+        );
+
+        // Assert
+        expect(renderAttempt).toThrow(/Cannot read properties of null/i);
+    });
+});


### PR DESCRIPTION
### Summary
Write unit test for Search page at client side

### Current Test Cases
**Search Page**
1. Render correctly with empty result
2. Render correctly with one result
3. Render correctly with multiple results
4. Render correctly with results that contains empty fields
5. Render correctly with results that contains `null` fields (user should realize that data is corrupted because not all information is shown, hence trying the refresh the page, so this behaviour should be acceptable)
Render throws error if results fails to resolve correctly

### Current Issues
1. Page fails to render due to typo in prop(`class` should be `className`)
2. Page title has typo (`Search Resuts` should be `Search Results`)
3. Page shows warning because array mapping does not include a key prop
4. If `result`s contains `null` description, the page crashes due to referencing of `substring` method

### Solution
1. Fix typo(change `class` to `className`)
2. Fix typo(change `Search Resuts` to `Search Results`)
3. Add key prop to array mapping
4. Change `.` to `?.` to avoid error due to dereferencing `null`