### PR TITLE
Test search context

### DIFF
--- a/client/src/context/search.js
+++ b/client/src/context/search.js
@@ -1,4 +1,4 @@
-import { useState, useContext, createContext } from "react";
+import React, { useState, useContext, createContext } from "react";
 
 const SearchContext = createContext();
 const SearchProvider = ({ children }) => {

--- a/client/src/context/search.test.js
+++ b/client/src/context/search.test.js
@@ -1,0 +1,42 @@
+import { renderHook, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { useSearch, SearchProvider } from "./search";
+
+describe('useSearch', () => {
+  it('should provide default values for search keyword and results correctly', () => {
+    // Arrange
+    const { result } = renderHook(() => useSearch(), {
+      wrapper: SearchProvider
+    });
+
+    // Act
+    const value = result.current[0];
+
+    // Assert
+    expect(value).toEqual({
+      keyword: "",
+      results: []
+    });
+  });
+
+  it('should allow user to update search context correctly', () => {
+    // Arrange
+    const { result } = renderHook(() => useSearch(), {
+      wrapper: SearchProvider
+    });
+    const mockValue = {
+      keyword: "Mock Keyword",
+      results: ["Mock Result"]
+    };
+
+    // Act
+    act(() => {
+      const setValue = result.current[1];
+      setValue(mockValue);
+    });
+    const value = result.current[0];
+
+    // Assert
+    expect(value).toEqual(mockValue);
+  });
+});


### PR DESCRIPTION
### Summary
Write unit test for Search Context for client side

### Current Test Cases
1. Check that search context provides the expected default value
2. Check that search context provides the set state function that changes the state correctly

### Current Issues
1. React runtime error due to missing React import for the context file. This is more like a dependency issue because the project still uses React 17/18 which does not allow React import to be excluded from the top of the file.

### Solution
1. import React at the top of the context file